### PR TITLE
Add git to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9-slim as py
 
 FROM py as build
 
-RUN apt update && apt install -y g++
+RUN apt update && apt install -y g++ git
 COPY requirements.txt /
 RUN pip install --prefix=/inst -U -r /requirements.txt
 


### PR DESCRIPTION
Since discord.py is installed via git in requirements.txt the Dockerfile needs to have git installed to download it.